### PR TITLE
Added alternative base config

### DIFF
--- a/conf/base_large.config
+++ b/conf/base_large.config
@@ -1,0 +1,72 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    dessimozlab/FastOMA Nextflow base config file with no resource maximum checking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    A 'blank slate' config file, appropriate for general use on most high performance
+    compute environments. Assumes that all software is installed and available on
+    the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
+    This config does not check for maximum available resources on the partition to allow
+    the scheduling between partitions with different resource limits.
+----------------------------------------------------------------------------------------
+*/
+
+process {
+
+    cpus   = {  1    * task.attempt  }
+    memory = { 6.GB * task.attempt }
+    time   = { 4.h  * task.attempt }
+    shell  = ['/bin/bash', '-euo', 'pipefail']
+
+    //errorStrategy = { task.exitStatus in (130..145) ? 'retry' : 'finish' }
+    errorStrategy = 'retry'
+    maxRetries    = 4
+
+    withLabel:process_single {
+        cpus   = { 1 }
+        memory = { 12.GB * task.attempt }
+        time   = { 4.h   * task.attempt }
+    }
+    withLabel:process_single_big {
+        cpus   = { 2 }
+        memory = { 30.GB * task.attempt  }
+        time   = { 24.h   * task.attempt }
+    }
+    withLabel:process_single_bigger {
+        cpus   = { 2 }
+        memory = { 70.GB * task.attempt  }
+        time   = { 24.h   * task.attempt }
+    }
+    withLabel:process_single_huge {
+        cpus   = { 2 }
+        memory = { 250.GB * task.attempt }
+        time   = { 48.h   * task.attempt }
+    }
+    withLabel:process_low {
+        cpus   = { 2     * task.attempt }
+        memory = { 12.GB * task.attempt }
+        time   = { 4.h   * task.attempt }
+    }
+    withLabel:process_medium {
+        cpus   = { 6     * task.attempt }
+        memory = { 36.GB * task.attempt }
+        time   = { 8.h   * task.attempt }
+    }
+    withLabel:process_high {
+        cpus   = { 12    * task.attempt }
+        memory = { 72.GB * task.attempt }
+        time   = { 16.h  * task.attempt }
+    }
+    withLabel:process_long {
+        time   = { 20.h  * task.attempt }
+    }
+    withLabel:process_high_memory {
+        memory = { 200.GB * task.attempt }
+    }
+    withLabel:error_ignore {
+        errorStrategy = 'ignore'
+    }
+    withLabel:error_retry {
+        errorStrategy = 'retry'
+        maxRetries    = 2
+    }
+}


### PR DESCRIPTION
Dear maintainers,

I have run FastOMA on about 2200 genomes and in order to make the run smoother I have created a customised base config.
The most important change is that I have removed the checking for maximum resource limits from the resource classes. The reson for this that our SLURM cluster has multiple partitions with different resource limits (e.g. bigmem) and the jobs are dynamically allocated to the appropriate queue. I found that with the current base config the jobs are always allocated to the default partition and hence some of them eventually run out of resources, crashing the pipeline.
Also, this config has resource classes with higher memory which can be specified for the processes in the main Nextflow file.
I would like to contribute this alterantive base config to the FastOMA repo in the hope that it will be useful for us and other users.

Best,
Botond