### PR TITLE
Requesting minimum set of config updates for big dataset

### DIFF
--- a/FastOMA.nf
+++ b/FastOMA.nf
@@ -217,7 +217,7 @@ process omamer_run{
 
 
 process infer_roothogs{
-  label "process_single"
+  label "process_medium"
   publishDir = [
     path: params.temp_output,
     enabled: params.debug_enabled,
@@ -410,6 +410,7 @@ process hog_rest{
 
 
 process collect_subhogs{
+  label "process_high"
   publishDir params.output_folder, mode: 'copy'
   input:
     path pickles, stageAs: "pickle_folders/?"
@@ -455,6 +456,7 @@ process extract_pairwise_ortholog_relations {
 
 
 process fastoma_report {
+  label "process_medium"
   publishDir params.output_folder, mode: 'copy'
   input:
     path notebook


### PR DESCRIPTION
Hi FastOMA team,

I have run FastOMA for:
800 species (excluding wheat)
800 species (including 19 wheat genomes)

The updates in this PR are the minimal configuration changes required to successfully run the 800-species dataset, including wheat. With these updates, the run (including 19 wheat genomes) completed in ~1 day 8 hours, indicating good scalability.

I’m happy to share the FastOMA reports for both runs if helpful.